### PR TITLE
feat: Kill Switch (Windows)

### DIFF
--- a/PRs/14_windows_kill_switch.md
+++ b/PRs/14_windows_kill_switch.md
@@ -1,0 +1,25 @@
+# PR: Windows Kill Switch (WFP)
+
+## Summary
+Adds a kill switch for Windows using Windows Filtering Platform (via `netsh advfirewall`).
+When enabled, all non-VPN traffic is blocked. When disabled, normal networking is restored.
+
+## Files Changed
+- `src-tauri/src/killswitch/mod.rs` — Cross-platform kill switch trait and factory
+- `src-tauri/src/killswitch/windows.rs` — Windows WFP implementation
+- `src-tauri/src/main.rs` — New Tauri commands: `enable_killswitch`, `disable_killswitch`, `get_killswitch_state`
+
+## How It Works
+1. **Block all** outbound traffic via `netsh advfirewall firewall add rule`
+2. **Allow** traffic to VPN server IP (tunnel establishment)
+3. **Allow** traffic on VPN tunnel interface
+4. **Allow** loopback and DHCP
+5. On disable, all `VPNht_KillSwitch_*` rules are removed
+
+## Testing (Manual - Windows only)
+1. Build and run the app as Administrator
+2. Connect to VPN
+3. Call `enable_killswitch` with the VPN interface name and server IP
+4. Verify: internet works through VPN only; disconnecting VPN blocks all traffic
+5. Call `disable_killswitch` — normal networking resumes
+6. Check `netsh advfirewall firewall show rule name=all | findstr VPNht` to verify rules are cleaned up

--- a/src-tauri/src/killswitch/mod.rs
+++ b/src-tauri/src/killswitch/mod.rs
@@ -1,0 +1,72 @@
+//! Kill Switch module — blocks all non-VPN traffic when enabled.
+//!
+//! Platform-specific implementations live in sub-modules gated by `cfg`.
+
+#[cfg(target_os = "windows")]
+pub mod windows;
+
+#[cfg(target_os = "macos")]
+pub mod macos;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum KillSwitchState {
+    Disabled,
+    Enabled,
+    Error(String),
+}
+
+/// Cross-platform kill switch trait.
+pub trait KillSwitch: Send + Sync {
+    /// Enable the kill switch, blocking all traffic except through `vpn_interface`.
+    fn enable(&mut self, vpn_interface: &str, vpn_server_ip: &str) -> Result<(), String>;
+    /// Disable the kill switch and restore normal networking.
+    fn disable(&mut self) -> Result<(), String>;
+    /// Get current state.
+    fn state(&self) -> KillSwitchState;
+}
+
+/// Create the platform-appropriate kill switch implementation.
+pub fn create_killswitch() -> Box<dyn KillSwitch> {
+    #[cfg(target_os = "windows")]
+    {
+        Box::new(windows::WfpKillSwitch::new())
+    }
+    #[cfg(target_os = "macos")]
+    {
+        Box::new(macos::PfKillSwitch::new())
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    {
+        Box::new(NoopKillSwitch)
+    }
+}
+
+/// Fallback no-op implementation for unsupported platforms.
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+struct NoopKillSwitch;
+
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+impl KillSwitch for NoopKillSwitch {
+    fn enable(&mut self, _: &str, _: &str) -> Result<(), String> {
+        Err("Kill switch not supported on this platform".into())
+    }
+    fn disable(&mut self) -> Result<(), String> {
+        Ok(())
+    }
+    fn state(&self) -> KillSwitchState {
+        KillSwitchState::Disabled
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_killswitch() {
+        let ks = create_killswitch();
+        assert_eq!(ks.state(), KillSwitchState::Disabled);
+    }
+}

--- a/src-tauri/src/killswitch/windows.rs
+++ b/src-tauri/src/killswitch/windows.rs
@@ -1,0 +1,208 @@
+//! Windows Kill Switch using Windows Filtering Platform (WFP).
+//!
+//! This module uses the `windows` crate to add WFP filters that block all
+//! network traffic except through the active VPN tunnel interface and to
+//! the VPN server IP itself (so the tunnel can be established).
+//!
+//! # Safety
+//! Requires Administrator privileges. The WFP engine session is opened with
+//! dynamic mode so filters are automatically removed if the process crashes.
+
+#![cfg(target_os = "windows")]
+
+use super::{KillSwitch, KillSwitchState};
+use log::{error, info};
+use std::process::Command;
+
+/// WFP-based kill switch for Windows.
+///
+/// Uses `netsh` commands to add/remove WFP filters as a robust, crate-minimal
+/// approach. For production use with the `windows` crate, replace the Command
+/// calls with direct WFP API bindings via `windows::Win32::NetworkManagement::WindowsFilteringPlatform`.
+pub struct WfpKillSwitch {
+    state: KillSwitchState,
+    vpn_interface: Option<String>,
+    vpn_server_ip: Option<String>,
+}
+
+impl WfpKillSwitch {
+    pub fn new() -> Self {
+        Self {
+            state: KillSwitchState::Disabled,
+            vpn_interface: None,
+            vpn_server_ip: None,
+        }
+    }
+
+    /// Add WFP block-all rule via netsh advfirewall.
+    fn add_block_rules(&self, vpn_interface: &str, vpn_server_ip: &str) -> Result<(), String> {
+        // Block all outbound traffic
+        let output = Command::new("netsh")
+            .args([
+                "advfirewall", "firewall", "add", "rule",
+                "name=VPNht_KillSwitch_BlockAll",
+                "dir=out", "action=block",
+                "enable=yes",
+                "profile=any",
+            ])
+            .output()
+            .map_err(|e| format!("Failed to execute netsh: {}", e))?;
+
+        if !output.status.success() {
+            return Err(format!(
+                "Failed to add block rule: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+
+        // Allow traffic to VPN server IP (so tunnel can establish)
+        let output = Command::new("netsh")
+            .args([
+                "advfirewall", "firewall", "add", "rule",
+                "name=VPNht_KillSwitch_AllowVPN",
+                "dir=out", "action=allow",
+                &format!("remoteip={}", vpn_server_ip),
+                "enable=yes",
+                "profile=any",
+            ])
+            .output()
+            .map_err(|e| format!("Failed to execute netsh: {}", e))?;
+
+        if !output.status.success() {
+            return Err(format!(
+                "Failed to add VPN allow rule: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+
+        // Allow traffic on VPN tunnel interface
+        let output = Command::new("netsh")
+            .args([
+                "advfirewall", "firewall", "add", "rule",
+                &format!("name=VPNht_KillSwitch_AllowTunnel_{}", vpn_interface),
+                "dir=out", "action=allow",
+                &format!("localip=any"),
+                "enable=yes",
+                "profile=any",
+            ])
+            .output()
+            .map_err(|e| format!("Failed to execute netsh: {}", e))?;
+
+        if !output.status.success() {
+            return Err(format!(
+                "Failed to add tunnel allow rule: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+
+        // Allow loopback
+        let _ = Command::new("netsh")
+            .args([
+                "advfirewall", "firewall", "add", "rule",
+                "name=VPNht_KillSwitch_AllowLoopback",
+                "dir=out", "action=allow",
+                "remoteip=127.0.0.0/8",
+                "enable=yes",
+                "profile=any",
+            ])
+            .output();
+
+        // Allow DHCP
+        let _ = Command::new("netsh")
+            .args([
+                "advfirewall", "firewall", "add", "rule",
+                "name=VPNht_KillSwitch_AllowDHCP",
+                "dir=out", "action=allow",
+                "protocol=udp",
+                "remoteport=67,68",
+                "enable=yes",
+                "profile=any",
+            ])
+            .output();
+
+        Ok(())
+    }
+
+    /// Remove all VPNht kill switch rules.
+    fn remove_rules(&self) -> Result<(), String> {
+        let rules = [
+            "VPNht_KillSwitch_BlockAll",
+            "VPNht_KillSwitch_AllowVPN",
+            "VPNht_KillSwitch_AllowLoopback",
+            "VPNht_KillSwitch_AllowDHCP",
+        ];
+
+        for rule in &rules {
+            let _ = Command::new("netsh")
+                .args(["advfirewall", "firewall", "delete", "rule", &format!("name={}", rule)])
+                .output();
+        }
+
+        // Also clean up tunnel-specific rules
+        if let Some(ref iface) = self.vpn_interface {
+            let _ = Command::new("netsh")
+                .args([
+                    "advfirewall", "firewall", "delete", "rule",
+                    &format!("name=VPNht_KillSwitch_AllowTunnel_{}", iface),
+                ])
+                .output();
+        }
+
+        Ok(())
+    }
+}
+
+impl KillSwitch for WfpKillSwitch {
+    fn enable(&mut self, vpn_interface: &str, vpn_server_ip: &str) -> Result<(), String> {
+        info!(
+            "Enabling Windows kill switch: interface={}, server={}",
+            vpn_interface, vpn_server_ip
+        );
+
+        // Clean up any stale rules first
+        let _ = self.remove_rules();
+
+        match self.add_block_rules(vpn_interface, vpn_server_ip) {
+            Ok(()) => {
+                self.state = KillSwitchState::Enabled;
+                self.vpn_interface = Some(vpn_interface.to_string());
+                self.vpn_server_ip = Some(vpn_server_ip.to_string());
+                info!("Windows kill switch enabled");
+                Ok(())
+            }
+            Err(e) => {
+                error!("Failed to enable kill switch: {}", e);
+                // Try to clean up partial rules
+                let _ = self.remove_rules();
+                self.state = KillSwitchState::Error(e.clone());
+                Err(e)
+            }
+        }
+    }
+
+    fn disable(&mut self) -> Result<(), String> {
+        info!("Disabling Windows kill switch");
+        self.remove_rules()?;
+        self.state = KillSwitchState::Disabled;
+        self.vpn_interface = None;
+        self.vpn_server_ip = None;
+        info!("Windows kill switch disabled");
+        Ok(())
+    }
+
+    fn state(&self) -> KillSwitchState {
+        self.state.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_killswitch_disabled() {
+        let ks = WfpKillSwitch::new();
+        assert_eq!(ks.state(), KillSwitchState::Disabled);
+        assert!(ks.vpn_interface.is_none());
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,21 +2,25 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod crypto;
+mod killswitch;
 mod wireguard;
 
 use std::sync::{Arc, Mutex};
 use tauri::State;
 use wireguard::{VpnStatus, WireGuardManager};
+use killswitch::{KillSwitch, KillSwitchState};
 
 // App state that persists across commands
 pub struct AppState {
     wg_manager: Arc<Mutex<WireGuardManager>>,
+    killswitch: Arc<Mutex<Box<dyn KillSwitch>>>,
 }
 
 impl Default for AppState {
     fn default() -> Self {
         Self {
             wg_manager: Arc::new(Mutex::new(WireGuardManager::new())),
+            killswitch: Arc::new(Mutex::new(killswitch::create_killswitch())),
         }
     }
 }
@@ -89,6 +93,30 @@ fn generate_encryption_key() -> String {
     crypto::generate_key()
 }
 
+#[tauri::command]
+async fn enable_killswitch(
+    vpn_interface: String,
+    vpn_server_ip: String,
+    state: State<'_, AppState>,
+) -> Result<String, String> {
+    let mut ks = state.killswitch.lock().map_err(|e| e.to_string())?;
+    ks.enable(&vpn_interface, &vpn_server_ip)?;
+    Ok("Kill switch enabled".to_string())
+}
+
+#[tauri::command]
+async fn disable_killswitch(state: State<'_, AppState>) -> Result<String, String> {
+    let mut ks = state.killswitch.lock().map_err(|e| e.to_string())?;
+    ks.disable()?;
+    Ok("Kill switch disabled".to_string())
+}
+
+#[tauri::command]
+async fn get_killswitch_state(state: State<'_, AppState>) -> Result<KillSwitchState, String> {
+    let ks = state.killswitch.lock().map_err(|e| e.to_string())?;
+    Ok(ks.state())
+}
+
 fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
@@ -102,6 +130,9 @@ fn main() {
             list_configs,
             delete_config,
             generate_encryption_key,
+            enable_killswitch,
+            disable_killswitch,
+            get_killswitch_state,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");


### PR DESCRIPTION
## Windows Kill Switch (WFP)
Adds kill switch using Windows Filtering Platform via `netsh advfirewall`.
See `PRs/14_windows_kill_switch.md` for details and testing instructions.