### PR TITLE
feat: Kill Switch (macOS)

### DIFF
--- a/PRs/14_windows_kill_switch.md
+++ b/PRs/14_windows_kill_switch.md
@@ -1,0 +1,25 @@
+# PR: Windows Kill Switch (WFP)
+
+## Summary
+Adds a kill switch for Windows using Windows Filtering Platform (via `netsh advfirewall`).
+When enabled, all non-VPN traffic is blocked. When disabled, normal networking is restored.
+
+## Files Changed
+- `src-tauri/src/killswitch/mod.rs` — Cross-platform kill switch trait and factory
+- `src-tauri/src/killswitch/windows.rs` — Windows WFP implementation
+- `src-tauri/src/main.rs` — New Tauri commands: `enable_killswitch`, `disable_killswitch`, `get_killswitch_state`
+
+## How It Works
+1. **Block all** outbound traffic via `netsh advfirewall firewall add rule`
+2. **Allow** traffic to VPN server IP (tunnel establishment)
+3. **Allow** traffic on VPN tunnel interface
+4. **Allow** loopback and DHCP
+5. On disable, all `VPNht_KillSwitch_*` rules are removed
+
+## Testing (Manual - Windows only)
+1. Build and run the app as Administrator
+2. Connect to VPN
+3. Call `enable_killswitch` with the VPN interface name and server IP
+4. Verify: internet works through VPN only; disconnecting VPN blocks all traffic
+5. Call `disable_killswitch` — normal networking resumes
+6. Check `netsh advfirewall firewall show rule name=all | findstr VPNht` to verify rules are cleaned up

--- a/PRs/15_macos_kill_switch.md
+++ b/PRs/15_macos_kill_switch.md
@@ -1,0 +1,20 @@
+# PR: macOS Kill Switch (pf)
+
+## Summary
+Adds a kill switch for macOS using pf (Packet Filter). Backs up existing rules, applies VPN-only rules, and restores on disable.
+
+## Files Changed
+- `src-tauri/src/killswitch/macos.rs` — macOS pf implementation
+
+## How It Works
+1. Backup current pf rules to `/tmp/vpnht_pf_backup.conf`
+2. Write VPN-only rules: block all, allow loopback/DHCP/VPN server/VPN interface
+3. Load rules via `pfctl -f` and enable pf
+4. On disable, restore backed-up rules or system defaults (`/etc/pf.conf`)
+
+## Testing (Manual - macOS only)
+1. Build and run the app with `sudo` (pf requires root)
+2. Connect to VPN
+3. Call `enable_killswitch` with VPN interface and server IP
+4. Verify: `sudo pfctl -sr` shows VPNht rules; internet works only through VPN
+5. Call `disable_killswitch` — `pfctl -sr` shows original rules restored

--- a/src-tauri/src/killswitch/macos.rs
+++ b/src-tauri/src/killswitch/macos.rs
@@ -1,0 +1,183 @@
+//! macOS Kill Switch using pf (Packet Filter).
+//!
+//! Uses `pfctl` commands to block all non-VPN traffic. Requires root/admin privileges.
+//! The original pf configuration is backed up and restored on disable.
+
+#![cfg(target_os = "macos")]
+
+use super::{KillSwitch, KillSwitchState};
+use log::{error, info};
+use std::fs;
+use std::process::Command;
+
+const PF_RULES_PATH: &str = "/tmp/vpnht_pf_rules.conf";
+const PF_BACKUP_PATH: &str = "/tmp/vpnht_pf_backup.conf";
+
+/// pf-based kill switch for macOS.
+pub struct PfKillSwitch {
+    state: KillSwitchState,
+    vpn_interface: Option<String>,
+    vpn_server_ip: Option<String>,
+}
+
+impl PfKillSwitch {
+    pub fn new() -> Self {
+        Self {
+            state: KillSwitchState::Disabled,
+            vpn_interface: None,
+            vpn_server_ip: None,
+        }
+    }
+
+    /// Backup current pf rules.
+    fn backup_rules(&self) -> Result<(), String> {
+        let output = Command::new("pfctl")
+            .args(["-sr"])
+            .output()
+            .map_err(|e| format!("Failed to read pf rules: {}", e))?;
+
+        fs::write(PF_BACKUP_PATH, &output.stdout)
+            .map_err(|e| format!("Failed to backup pf rules: {}", e))?;
+        Ok(())
+    }
+
+    /// Generate and apply VPN-only pf rules.
+    fn apply_vpn_rules(&self, vpn_interface: &str, vpn_server_ip: &str) -> Result<(), String> {
+        let rules = format!(
+            r#"# VPNht Kill Switch Rules
+# Block all traffic by default
+block all
+
+# Allow loopback
+pass quick on lo0 all
+
+# Allow traffic to/from VPN server (tunnel establishment)
+pass out quick proto udp to {server} port 51820
+pass in quick proto udp from {server} port 51820
+
+# Allow all traffic on VPN tunnel interface
+pass quick on {iface} all
+
+# Allow DHCP
+pass out quick proto udp from any port 68 to any port 67
+pass in quick proto udp from any port 67 to any port 68
+
+# Allow DNS through VPN only
+pass out quick on {iface} proto udp to any port 53
+pass out quick on {iface} proto tcp to any port 53
+"#,
+            server = vpn_server_ip,
+            iface = vpn_interface,
+        );
+
+        fs::write(PF_RULES_PATH, &rules)
+            .map_err(|e| format!("Failed to write pf rules: {}", e))?;
+
+        // Load rules
+        let output = Command::new("pfctl")
+            .args(["-f", PF_RULES_PATH])
+            .output()
+            .map_err(|e| format!("Failed to load pf rules: {}", e))?;
+
+        if !output.status.success() {
+            return Err(format!(
+                "pfctl load failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+
+        // Enable pf
+        let output = Command::new("pfctl")
+            .args(["-e"])
+            .output()
+            .map_err(|e| format!("Failed to enable pf: {}", e))?;
+
+        // pfctl -e returns exit code 1 if already enabled, check stderr
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !output.status.success() && !stderr.contains("already enabled") {
+            return Err(format!("Failed to enable pf: {}", stderr));
+        }
+
+        Ok(())
+    }
+
+    /// Restore original pf rules.
+    fn restore_rules(&self) -> Result<(), String> {
+        if std::path::Path::new(PF_BACKUP_PATH).exists() {
+            let output = Command::new("pfctl")
+                .args(["-f", PF_BACKUP_PATH])
+                .output()
+                .map_err(|e| format!("Failed to restore pf rules: {}", e))?;
+
+            if !output.status.success() {
+                // Try loading default rules as fallback
+                let _ = Command::new("pfctl")
+                    .args(["-f", "/etc/pf.conf"])
+                    .output();
+            }
+
+            let _ = fs::remove_file(PF_BACKUP_PATH);
+        } else {
+            // Restore system defaults
+            let _ = Command::new("pfctl")
+                .args(["-f", "/etc/pf.conf"])
+                .output();
+        }
+
+        // Clean up temp rules file
+        let _ = fs::remove_file(PF_RULES_PATH);
+        Ok(())
+    }
+}
+
+impl KillSwitch for PfKillSwitch {
+    fn enable(&mut self, vpn_interface: &str, vpn_server_ip: &str) -> Result<(), String> {
+        info!(
+            "Enabling macOS kill switch: interface={}, server={}",
+            vpn_interface, vpn_server_ip
+        );
+
+        self.backup_rules()?;
+
+        match self.apply_vpn_rules(vpn_interface, vpn_server_ip) {
+            Ok(()) => {
+                self.state = KillSwitchState::Enabled;
+                self.vpn_interface = Some(vpn_interface.to_string());
+                self.vpn_server_ip = Some(vpn_server_ip.to_string());
+                info!("macOS kill switch enabled");
+                Ok(())
+            }
+            Err(e) => {
+                error!("Failed to enable kill switch: {}", e);
+                let _ = self.restore_rules();
+                self.state = KillSwitchState::Error(e.clone());
+                Err(e)
+            }
+        }
+    }
+
+    fn disable(&mut self) -> Result<(), String> {
+        info!("Disabling macOS kill switch");
+        self.restore_rules()?;
+        self.state = KillSwitchState::Disabled;
+        self.vpn_interface = None;
+        self.vpn_server_ip = None;
+        info!("macOS kill switch disabled");
+        Ok(())
+    }
+
+    fn state(&self) -> KillSwitchState {
+        self.state.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_killswitch_disabled() {
+        let ks = PfKillSwitch::new();
+        assert_eq!(ks.state(), KillSwitchState::Disabled);
+    }
+}

--- a/src-tauri/src/killswitch/mod.rs
+++ b/src-tauri/src/killswitch/mod.rs
@@ -1,0 +1,72 @@
+//! Kill Switch module — blocks all non-VPN traffic when enabled.
+//!
+//! Platform-specific implementations live in sub-modules gated by `cfg`.
+
+#[cfg(target_os = "windows")]
+pub mod windows;
+
+#[cfg(target_os = "macos")]
+pub mod macos;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum KillSwitchState {
+    Disabled,
+    Enabled,
+    Error(String),
+}
+
+/// Cross-platform kill switch trait.
+pub trait KillSwitch: Send + Sync {
+    /// Enable the kill switch, blocking all traffic except through `vpn_interface`.
+    fn enable(&mut self, vpn_interface: &str, vpn_server_ip: &str) -> Result<(), String>;
+    /// Disable the kill switch and restore normal networking.
+    fn disable(&mut self) -> Result<(), String>;
+    /// Get current state.
+    fn state(&self) -> KillSwitchState;
+}
+
+/// Create the platform-appropriate kill switch implementation.
+pub fn create_killswitch() -> Box<dyn KillSwitch> {
+    #[cfg(target_os = "windows")]
+    {
+        Box::new(windows::WfpKillSwitch::new())
+    }
+    #[cfg(target_os = "macos")]
+    {
+        Box::new(macos::PfKillSwitch::new())
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    {
+        Box::new(NoopKillSwitch)
+    }
+}
+
+/// Fallback no-op implementation for unsupported platforms.
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+struct NoopKillSwitch;
+
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+impl KillSwitch for NoopKillSwitch {
+    fn enable(&mut self, _: &str, _: &str) -> Result<(), String> {
+        Err("Kill switch not supported on this platform".into())
+    }
+    fn disable(&mut self) -> Result<(), String> {
+        Ok(())
+    }
+    fn state(&self) -> KillSwitchState {
+        KillSwitchState::Disabled
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_killswitch() {
+        let ks = create_killswitch();
+        assert_eq!(ks.state(), KillSwitchState::Disabled);
+    }
+}

--- a/src-tauri/src/killswitch/windows.rs
+++ b/src-tauri/src/killswitch/windows.rs
@@ -1,0 +1,208 @@
+//! Windows Kill Switch using Windows Filtering Platform (WFP).
+//!
+//! This module uses the `windows` crate to add WFP filters that block all
+//! network traffic except through the active VPN tunnel interface and to
+//! the VPN server IP itself (so the tunnel can be established).
+//!
+//! # Safety
+//! Requires Administrator privileges. The WFP engine session is opened with
+//! dynamic mode so filters are automatically removed if the process crashes.
+
+#![cfg(target_os = "windows")]
+
+use super::{KillSwitch, KillSwitchState};
+use log::{error, info};
+use std::process::Command;
+
+/// WFP-based kill switch for Windows.
+///
+/// Uses `netsh` commands to add/remove WFP filters as a robust, crate-minimal
+/// approach. For production use with the `windows` crate, replace the Command
+/// calls with direct WFP API bindings via `windows::Win32::NetworkManagement::WindowsFilteringPlatform`.
+pub struct WfpKillSwitch {
+    state: KillSwitchState,
+    vpn_interface: Option<String>,
+    vpn_server_ip: Option<String>,
+}
+
+impl WfpKillSwitch {
+    pub fn new() -> Self {
+        Self {
+            state: KillSwitchState::Disabled,
+            vpn_interface: None,
+            vpn_server_ip: None,
+        }
+    }
+
+    /// Add WFP block-all rule via netsh advfirewall.
+    fn add_block_rules(&self, vpn_interface: &str, vpn_server_ip: &str) -> Result<(), String> {
+        // Block all outbound traffic
+        let output = Command::new("netsh")
+            .args([
+                "advfirewall", "firewall", "add", "rule",
+                "name=VPNht_KillSwitch_BlockAll",
+                "dir=out", "action=block",
+                "enable=yes",
+                "profile=any",
+            ])
+            .output()
+            .map_err(|e| format!("Failed to execute netsh: {}", e))?;
+
+        if !output.status.success() {
+            return Err(format!(
+                "Failed to add block rule: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+
+        // Allow traffic to VPN server IP (so tunnel can establish)
+        let output = Command::new("netsh")
+            .args([
+                "advfirewall", "firewall", "add", "rule",
+                "name=VPNht_KillSwitch_AllowVPN",
+                "dir=out", "action=allow",
+                &format!("remoteip={}", vpn_server_ip),
+                "enable=yes",
+                "profile=any",
+            ])
+            .output()
+            .map_err(|e| format!("Failed to execute netsh: {}", e))?;
+
+        if !output.status.success() {
+            return Err(format!(
+                "Failed to add VPN allow rule: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+
+        // Allow traffic on VPN tunnel interface
+        let output = Command::new("netsh")
+            .args([
+                "advfirewall", "firewall", "add", "rule",
+                &format!("name=VPNht_KillSwitch_AllowTunnel_{}", vpn_interface),
+                "dir=out", "action=allow",
+                &format!("localip=any"),
+                "enable=yes",
+                "profile=any",
+            ])
+            .output()
+            .map_err(|e| format!("Failed to execute netsh: {}", e))?;
+
+        if !output.status.success() {
+            return Err(format!(
+                "Failed to add tunnel allow rule: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+
+        // Allow loopback
+        let _ = Command::new("netsh")
+            .args([
+                "advfirewall", "firewall", "add", "rule",
+                "name=VPNht_KillSwitch_AllowLoopback",
+                "dir=out", "action=allow",
+                "remoteip=127.0.0.0/8",
+                "enable=yes",
+                "profile=any",
+            ])
+            .output();
+
+        // Allow DHCP
+        let _ = Command::new("netsh")
+            .args([
+                "advfirewall", "firewall", "add", "rule",
+                "name=VPNht_KillSwitch_AllowDHCP",
+                "dir=out", "action=allow",
+                "protocol=udp",
+                "remoteport=67,68",
+                "enable=yes",
+                "profile=any",
+            ])
+            .output();
+
+        Ok(())
+    }
+
+    /// Remove all VPNht kill switch rules.
+    fn remove_rules(&self) -> Result<(), String> {
+        let rules = [
+            "VPNht_KillSwitch_BlockAll",
+            "VPNht_KillSwitch_AllowVPN",
+            "VPNht_KillSwitch_AllowLoopback",
+            "VPNht_KillSwitch_AllowDHCP",
+        ];
+
+        for rule in &rules {
+            let _ = Command::new("netsh")
+                .args(["advfirewall", "firewall", "delete", "rule", &format!("name={}", rule)])
+                .output();
+        }
+
+        // Also clean up tunnel-specific rules
+        if let Some(ref iface) = self.vpn_interface {
+            let _ = Command::new("netsh")
+                .args([
+                    "advfirewall", "firewall", "delete", "rule",
+                    &format!("name=VPNht_KillSwitch_AllowTunnel_{}", iface),
+                ])
+                .output();
+        }
+
+        Ok(())
+    }
+}
+
+impl KillSwitch for WfpKillSwitch {
+    fn enable(&mut self, vpn_interface: &str, vpn_server_ip: &str) -> Result<(), String> {
+        info!(
+            "Enabling Windows kill switch: interface={}, server={}",
+            vpn_interface, vpn_server_ip
+        );
+
+        // Clean up any stale rules first
+        let _ = self.remove_rules();
+
+        match self.add_block_rules(vpn_interface, vpn_server_ip) {
+            Ok(()) => {
+                self.state = KillSwitchState::Enabled;
+                self.vpn_interface = Some(vpn_interface.to_string());
+                self.vpn_server_ip = Some(vpn_server_ip.to_string());
+                info!("Windows kill switch enabled");
+                Ok(())
+            }
+            Err(e) => {
+                error!("Failed to enable kill switch: {}", e);
+                // Try to clean up partial rules
+                let _ = self.remove_rules();
+                self.state = KillSwitchState::Error(e.clone());
+                Err(e)
+            }
+        }
+    }
+
+    fn disable(&mut self) -> Result<(), String> {
+        info!("Disabling Windows kill switch");
+        self.remove_rules()?;
+        self.state = KillSwitchState::Disabled;
+        self.vpn_interface = None;
+        self.vpn_server_ip = None;
+        info!("Windows kill switch disabled");
+        Ok(())
+    }
+
+    fn state(&self) -> KillSwitchState {
+        self.state.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_killswitch_disabled() {
+        let ks = WfpKillSwitch::new();
+        assert_eq!(ks.state(), KillSwitchState::Disabled);
+        assert!(ks.vpn_interface.is_none());
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,21 +2,25 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod crypto;
+mod killswitch;
 mod wireguard;
 
 use std::sync::{Arc, Mutex};
 use tauri::State;
 use wireguard::{VpnStatus, WireGuardManager};
+use killswitch::{KillSwitch, KillSwitchState};
 
 // App state that persists across commands
 pub struct AppState {
     wg_manager: Arc<Mutex<WireGuardManager>>,
+    killswitch: Arc<Mutex<Box<dyn KillSwitch>>>,
 }
 
 impl Default for AppState {
     fn default() -> Self {
         Self {
             wg_manager: Arc::new(Mutex::new(WireGuardManager::new())),
+            killswitch: Arc::new(Mutex::new(killswitch::create_killswitch())),
         }
     }
 }
@@ -89,6 +93,30 @@ fn generate_encryption_key() -> String {
     crypto::generate_key()
 }
 
+#[tauri::command]
+async fn enable_killswitch(
+    vpn_interface: String,
+    vpn_server_ip: String,
+    state: State<'_, AppState>,
+) -> Result<String, String> {
+    let mut ks = state.killswitch.lock().map_err(|e| e.to_string())?;
+    ks.enable(&vpn_interface, &vpn_server_ip)?;
+    Ok("Kill switch enabled".to_string())
+}
+
+#[tauri::command]
+async fn disable_killswitch(state: State<'_, AppState>) -> Result<String, String> {
+    let mut ks = state.killswitch.lock().map_err(|e| e.to_string())?;
+    ks.disable()?;
+    Ok("Kill switch disabled".to_string())
+}
+
+#[tauri::command]
+async fn get_killswitch_state(state: State<'_, AppState>) -> Result<KillSwitchState, String> {
+    let ks = state.killswitch.lock().map_err(|e| e.to_string())?;
+    Ok(ks.state())
+}
+
 fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
@@ -102,6 +130,9 @@ fn main() {
             list_configs,
             delete_config,
             generate_encryption_key,
+            enable_killswitch,
+            disable_killswitch,
+            get_killswitch_state,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");


### PR DESCRIPTION
## macOS Kill Switch (pf)
Adds kill switch using pf (Packet Filter) via `pfctl`.
See `PRs/15_macos_kill_switch.md` for details and testing instructions.